### PR TITLE
Saidatta/feed card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32077,7 +32077,7 @@
     },
     "packages/component": {
       "name": "@blue-learn/component",
-      "version": "0.0.33",
+      "version": "0.0.35",
       "license": "ISC",
       "dependencies": {
         "lodash-es": "^4.17.21",
@@ -32089,29 +32089,17 @@
         "react-native-web-lottie": "^1.4.4"
       },
       "devDependencies": {
-        "@blue-learn/schema": "^0.0.32",
-        "@blue-learn/theme": "^0.0.32",
+        "@blue-learn/schema": "^0.0.35",
+        "@blue-learn/theme": "^0.0.35",
         "@types/react": "^17.0.38",
         "react": "^17.0.2",
         "react-native": "^0.69.0",
         "typescript": "^4.5.5"
       }
     },
-    "packages/component/node_modules/@blue-learn/schema": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@blue-learn/schema/-/schema-0.0.32.tgz",
-      "integrity": "sha512-j103q/ZQ7OSFSKYHV8f/IpJn5gc3NOB7HqSSHwGkbJXXCQdx3O5mlCHCyULytlfpMNq4zkZc9d3AN54jvvAaBQ==",
-      "dev": true
-    },
-    "packages/component/node_modules/@blue-learn/theme": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@blue-learn/theme/-/theme-0.0.32.tgz",
-      "integrity": "sha512-TdqRYtciipFNL1JVqRiBhc9Vh/EPlWNInF77ELrjk+vHKF+Xj5YBR7ncK0ea/hf1Kk7toKc2huvBGsm8jqqCBA==",
-      "dev": true
-    },
     "packages/schema": {
       "name": "@blue-learn/schema",
-      "version": "0.0.33",
+      "version": "0.0.35",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^4.5.5"
@@ -32119,10 +32107,10 @@
     },
     "packages/theme": {
       "name": "@blue-learn/theme",
-      "version": "0.0.33",
+      "version": "0.0.35",
       "license": "ISC",
       "devDependencies": {
-        "@blue-learn/schema": "^0.0.33",
+        "@blue-learn/schema": "^0.0.35",
         "typescript": "^4.5.5"
       }
     }
@@ -33211,8 +33199,8 @@
     "@blue-learn/component": {
       "version": "file:packages/component",
       "requires": {
-        "@blue-learn/schema": "^0.0.32",
-        "@blue-learn/theme": "^0.0.32",
+        "@blue-learn/schema": "^0.0.35",
+        "@blue-learn/theme": "^0.0.35",
         "@types/react": "^17.0.38",
         "lodash-es": "^4.17.21",
         "lottie-react-native": "^5.1.3",
@@ -33224,20 +33212,6 @@
         "react-native-web-linear-gradient": "^1.1.2",
         "react-native-web-lottie": "^1.4.4",
         "typescript": "^4.5.5"
-      },
-      "dependencies": {
-        "@blue-learn/schema": {
-          "version": "0.0.32",
-          "resolved": "https://registry.npmjs.org/@blue-learn/schema/-/schema-0.0.32.tgz",
-          "integrity": "sha512-j103q/ZQ7OSFSKYHV8f/IpJn5gc3NOB7HqSSHwGkbJXXCQdx3O5mlCHCyULytlfpMNq4zkZc9d3AN54jvvAaBQ==",
-          "dev": true
-        },
-        "@blue-learn/theme": {
-          "version": "0.0.32",
-          "resolved": "https://registry.npmjs.org/@blue-learn/theme/-/theme-0.0.32.tgz",
-          "integrity": "sha512-TdqRYtciipFNL1JVqRiBhc9Vh/EPlWNInF77ELrjk+vHKF+Xj5YBR7ncK0ea/hf1Kk7toKc2huvBGsm8jqqCBA==",
-          "dev": true
-        }
       }
     },
     "@blue-learn/schema": {
@@ -33249,7 +33223,7 @@
     "@blue-learn/theme": {
       "version": "file:packages/theme",
       "requires": {
-        "@blue-learn/schema": "^0.0.33",
+        "@blue-learn/schema": "^0.0.35",
         "typescript": "^4.5.5"
       }
     },

--- a/packages/component/src/chip/Chip.base.tsx
+++ b/packages/component/src/chip/Chip.base.tsx
@@ -6,36 +6,41 @@ import {
 	FontFamilyTokens,
 	FontSizeTokens,
 	IconAlignmentTokens,
-	IconTokens,
+	ImageSizeTokens,
 	SizeTypeTokens,
+	WidgetProps,
 } from '@blue-learn/schema';
 import React, { memo } from 'react';
-import { View } from 'react-native';
+import { Pressable } from 'react-native';
 import ThemeProvider from '@blue-learn/theme';
 import Typography from '../typography/Typography';
 import Icon from '../icon/Icon';
 import Space from '../space/Space';
+import { Image } from '../image/Image';
 
 /**
  * @description
  * Stack supports children as React Component and widgetItems as WidgetItem Type[order by children -> widgetItems]
  * Note: renderItem should be passed to render WidgetItem
  **/
-const Chip: React.FC<ChipItemProps> = ({
+const Chip: React.FC<
+	ChipItemProps & WidgetProps
+> = ({
 	label = 'Chip',
 	bgColor = ColorTokens.Grey_600,
 	labelColor = ColorTokens.Grey_100,
 	fontSize = FontSizeTokens.XS,
 	state = ChipStateTokens.DEFAULT,
 	borderRadius = BorderRadiusTokens.BR4,
-	icon = {
-		name: IconTokens.Sparkling,
-		align: IconAlignmentTokens.left,
-	},
+	icon,
+	image,
 	padding = {
 		horizontal: SizeTypeTokens.MD,
 		vertical: SizeTypeTokens.SM,
 	},
+	onPress,
+	action,
+	triggerAction,
 }) => {
 	const theme = ThemeProvider.getTheme();
 
@@ -65,8 +70,20 @@ const Chip: React.FC<ChipItemProps> = ({
 			padding?.horizontal || padding?.right
 		];
 
+	const labelColorValue =
+		state === ChipStateTokens.DEFAULT
+			? labelColor
+			: ColorTokens.Grey_500;
+
+	const handleAction = () => {
+		onPress && onPress();
+		action &&
+			triggerAction &&
+			triggerAction(action);
+	};
+
 	return (
-		<View
+		<Pressable
 			style={{
 				flexDirection: 'row',
 				alignItems: 'center',
@@ -77,25 +94,36 @@ const Chip: React.FC<ChipItemProps> = ({
 				paddingLeft: paddingLeft,
 				paddingRight: paddingRight,
 			}}
+			onPress={handleAction}
 		>
 			{icon?.align === IconAlignmentTokens.left &&
 				icon?.name && (
 					<>
-						<Icon {...icon} />
+						<Icon
+							{...icon}
+							color={icon?.color || labelColorValue}
+						/>
 						{label && (
 							<Space size={SizeTypeTokens.SM} />
 						)}
 					</>
 				)}
+
+			{image && image?.uri
+				? [
+						<Image
+							size={image?.size || ImageSizeTokens.XXS}
+							{...image}
+						/>,
+						<Space size={SizeTypeTokens.SM} />,
+				  ]
+				: null}
+
 			<Typography
 				label={label}
 				fontSize={fontSize}
 				fontFamily={FontFamilyTokens.manropeSemiBold}
-				color={
-					state === ChipStateTokens.DEFAULT
-						? labelColor
-						: ColorTokens.Grey_500
-				}
+				color={labelColorValue}
 			/>
 			{icon?.align === IconAlignmentTokens.right &&
 				icon?.name && (
@@ -103,10 +131,13 @@ const Chip: React.FC<ChipItemProps> = ({
 						{label && (
 							<Space size={SizeTypeTokens.SM} />
 						)}
-						<Icon {...icon} />
+						<Icon
+							{...icon}
+							color={icon?.color || labelColorValue}
+						/>
 					</>
 				)}
-		</View>
+		</Pressable>
 	);
 };
 

--- a/packages/component/src/chip/Chip.mock.tsx
+++ b/packages/component/src/chip/Chip.mock.tsx
@@ -1,36 +1,27 @@
 import {
-	AvatarSizeTokens,
 	ChipProps,
 	ChipStateTokens,
-	ColorTokens,
 	IconAlignmentTokens,
 	IconSizeTokens,
 	IconTokens,
+	ImageSizeTokens,
 } from '@blue-learn/schema';
-
-export default {
-	uri: 'https://reactnative.dev/img/tiny_logo.png',
-	size: AvatarSizeTokens.LG,
-};
 
 export const args: ChipProps = {
 	data: [
 		{
 			label: 'Chip1',
 			state: ChipStateTokens.DEFAULT,
-			icon: {
-				name: IconTokens.Sparkling,
-				color: ColorTokens.Grey_100,
-				size: IconSizeTokens.XXS,
-				align: IconAlignmentTokens.left,
+			image: {
+				size: ImageSizeTokens.XXS,
+				uri: 'https://reactnative.dev/img/tiny_logo.png',
 			},
 		},
 		{
 			label: 'Chip2',
 			state: ChipStateTokens.ACTIVE,
 			icon: {
-				name: IconTokens.Sparkling,
-				color: ColorTokens.Grey_100,
+				name: IconTokens.Attachment,
 				size: IconSizeTokens.XXS,
 				align: IconAlignmentTokens.left,
 			},

--- a/packages/component/src/userCard/UserCard.mock.tsx
+++ b/packages/component/src/userCard/UserCard.mock.tsx
@@ -2,6 +2,7 @@ import { UserCardProps } from '@blue-learn/schema';
 
 export const args: UserCardProps = {
 	title: 'Saidatta Sahu',
+	title_secondary: '6 Day',
 	subtitle: 'Software Engineer',
 	avatar:
 		'https://reactnative.dev/img/tiny_logo.png',

--- a/packages/component/src/userCard/UserCard.tsx
+++ b/packages/component/src/userCard/UserCard.tsx
@@ -60,7 +60,11 @@ const UserCard: React.FunctionComponent<
 							size={AvatarSizeTokens.MD}
 						/>
 						<Space size={SizeTypeTokens.MD} />
-						<Stack>
+						<View
+							style={{
+								flex: 1,
+							}}
+						>
 							<Stack
 								type={StackType.row}
 								alignItems={StackAlignItems.center}
@@ -80,8 +84,8 @@ const UserCard: React.FunctionComponent<
 								</View>
 								{title_secondary ? (
 									<Typography
-										label={'      ' + title_secondary}
-										type={TypographyTypeTokens.B5}
+										label={title_secondary}
+										type={TypographyTypeTokens.B7}
 										color={ColorTokens.Grey_200}
 									/>
 								) : (
@@ -114,7 +118,7 @@ const UserCard: React.FunctionComponent<
 									color={ColorTokens.Grey_200}
 								/>
 							)}
-						</Stack>
+						</View>
 					</Stack>
 				),
 			}}

--- a/packages/schema/src/chip/index.ts
+++ b/packages/schema/src/chip/index.ts
@@ -4,6 +4,7 @@ import { IconProps } from '../icon';
 import { OpacityTypeTokens } from '../opacity';
 import { PaddingProps } from '../padding';
 import { FontSizeTokens } from '../typography';
+import { ImageProps } from '../image';
 
 export enum ChipStateTokens {
 	DEFAULT = 'DEFAULT',
@@ -16,6 +17,7 @@ export type ChipItemProps = {
 	/**
 	 * Default Icon null
 	 */
+	image?: ImageProps;
 	icon?: IconProps;
 	bgColor?: ColorTokens;
 	labelColor?: ColorTokens;
@@ -23,6 +25,7 @@ export type ChipItemProps = {
 	borderRadius?: BorderRadiusTokens;
 	opacity?: OpacityTypeTokens;
 	padding?: PaddingProps;
+	onPress?: Function;
 };
 
 export type ChipProps = {


### PR DESCRIPTION
### secondary title in user card added
<img width="429" alt="Screenshot 2022-09-06 at 3 55 35 PM" src="https://user-images.githubusercontent.com/45597332/188612210-f0b6aa63-b363-4a48-bb6c-4afc3938d016.png">


### image and icon support in chip component added
<img width="185" alt="Screenshot 2022-09-06 at 3 55 57 PM" src="https://user-images.githubusercontent.com/45597332/188612235-6d518cd0-ecb4-46af-9827-8ad3e7ea9e81.png">
